### PR TITLE
Add comma to subtype enum example

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2693,7 +2693,7 @@ enum Color =&gt; qw( red blue green );
 my %ok = map { $_ =&gt; 1 }
              qw( red blue green );
 
-subtype     'Color'
+subtype     'Color',
     as      'Str',
     where   { $ok{$_} },
     message { ... };</code></pre>


### PR DESCRIPTION
The enum subtype example is missing a comma; this fixes that.
